### PR TITLE
#26 allow connecting through http server

### DIFF
--- a/Source/EphysSocket.cpp
+++ b/Source/EphysSocket.cpp
@@ -61,9 +61,7 @@ void EphysSocket::disconnectSocket()
 
 bool EphysSocket::connectSocket (bool printOutput)
 {
-    const bool connected = socket.connectSocket (port, printOutput);
-
-    if (connected)
+    if (socket.connectSocket (port, printOutput))
     {
         getParameter ("port")->setEnabled (false);
         getParameter ("sample_rate")->setEnabled (false);
@@ -72,9 +70,11 @@ bool EphysSocket::connectSocket (bool printOutput)
 
         if (sn->getEditor() != nullptr) // check if headless
             static_cast<EphysSocketEditor*> (sn->getEditor())->connected();
+
+        return true;
     }
 
-    return connected;
+    return false;
 }
 
 bool EphysSocket::errorFlag()

--- a/Source/EphysSocket.cpp
+++ b/Source/EphysSocket.cpp
@@ -48,7 +48,7 @@ void EphysSocket::registerParameters()
 void EphysSocket::disconnectSocket()
 {
     socket.signalThreadShouldExit();
-    socket.waitForThreadToExit (1000);
+    socket.waitForThreadToExit(1000);
     socket.disconnectSocket();
 
     getParameter ("port")->setEnabled (true);
@@ -182,6 +182,10 @@ void EphysSocket::parameterValueChanged (Parameter* parameter)
     }
     else if (parameter->getName() == "connection_state")
     {
+        // This is mainly useful when the application settings have
+        // for some reason saved connection_state DISCONNECTED. At 
+        // startup, the connection state will be synced with the actual
+        // state of the socket
         parameter->setNextValue (socket.isConnected() ? CONNECTION_STATE_CONNECTED : CONNECTION_STATE_DISCONNECTED);
     }
 }

--- a/Source/EphysSocket.h
+++ b/Source/EphysSocket.h
@@ -12,8 +12,8 @@ class EphysSocket : public DataThread
 {
 public:
     /** Connection states */
-    static const constexpr char const* CONNECTION_STATE_CONNECTED { "CONNECTED" };
-    static const constexpr char const* CONNECTION_STATE_DISCONNECTED { "DISCONNECTED" };
+    static const constexpr char* CONNECTION_STATE_CONNECTED { "CONNECTED" };
+    static const constexpr char* CONNECTION_STATE_DISCONNECTED { "DISCONNECTED" };
 
     /** Default parameters */
     static constexpr int DEFAULT_PORT { 9001 };

--- a/Source/EphysSocket.h
+++ b/Source/EphysSocket.h
@@ -20,7 +20,6 @@ public:
     static constexpr float DEFAULT_SAMPLE_RATE { 30000.0f };
     static constexpr float DEFAULT_DATA_SCALE { 1.0f }; // 0.195f for Intan devices
     static constexpr float DEFAULT_DATA_OFFSET { 0.0f }; // 32768.0f for Intan devices
-    static constexpr char const* DEFAULT_CONNECTION_STATE { CONNECTION_STATE_DISCONNECTED };
 
     /** Parameter limits */
     static constexpr float MIN_DATA_SCALE { 0.0f };

--- a/Source/EphysSocket.h
+++ b/Source/EphysSocket.h
@@ -11,21 +11,26 @@ namespace EphysSocketNode
 class EphysSocket : public DataThread
 {
 public:
+    /** Connection states */
+    static const constexpr char const* CONNECTION_STATE_CONNECTED { "CONNECTED" };
+    static const constexpr char const* CONNECTION_STATE_DISCONNECTED { "DISCONNECTED" };
+
     /** Default parameters */
-    const int DEFAULT_PORT = 9001;
-    const float DEFAULT_SAMPLE_RATE = 30000.0f;
-    const float DEFAULT_DATA_SCALE = 1.0f; // 0.195f for Intan devices
-    const float DEFAULT_DATA_OFFSET = 0.0f; // 32768.0f for Intan devices
+    static constexpr int DEFAULT_PORT { 9001 };
+    static constexpr float DEFAULT_SAMPLE_RATE { 30000.0f };
+    static constexpr float DEFAULT_DATA_SCALE { 1.0f }; // 0.195f for Intan devices
+    static constexpr float DEFAULT_DATA_OFFSET { 0.0f }; // 32768.0f for Intan devices
+    static constexpr char const* DEFAULT_CONNECTION_STATE { CONNECTION_STATE_DISCONNECTED };
 
     /** Parameter limits */
-    const float MIN_DATA_SCALE = 0.0f;
-    const float MAX_DATA_SCALE = 9999.9f;
-    const float MIN_DATA_OFFSET = 0;
-    const float MAX_DATA_OFFSET = 65536;
-    const float MIN_PORT = 1023;
-    const float MAX_PORT = 65535;
-    const float MIN_SAMPLE_RATE = 0;
-    const float MAX_SAMPLE_RATE = 50000.0f;
+    static constexpr float MIN_DATA_SCALE { 0.0f };
+    static constexpr float MAX_DATA_SCALE { 9999.9f };
+    static constexpr float MIN_DATA_OFFSET { 0 };
+    static constexpr float MAX_DATA_OFFSET { 65536 };
+    static constexpr float MIN_PORT { 1023 };
+    static constexpr float MAX_PORT { 65535 };
+    static constexpr float MIN_SAMPLE_RATE { 0 };
+    static constexpr float MAX_SAMPLE_RATE { 50000.0f };
 
     /** Constructor */
     EphysSocket (SourceNode* sn);

--- a/Source/EphysSocket.h
+++ b/Source/EphysSocket.h
@@ -39,7 +39,7 @@ public:
     ~EphysSocket();
 
     /** Creates custom editor */
-    std::unique_ptr<GenericEditor> createEditor (SourceNode* sn);
+    std::unique_ptr<GenericEditor> createEditor (SourceNode* sn) override;
 
     /** Create the DataThread object*/
     static DataThread* createDataThread (SourceNode* sn);
@@ -56,13 +56,13 @@ public:
                          OwnedArray<SpikeChannel>* spikeChannels,
                          OwnedArray<DataStream>* sourceStreams,
                          OwnedArray<DeviceInfo>* devices,
-                         OwnedArray<ConfigurationObject>* configurationObjects);
+                         OwnedArray<ConfigurationObject>* configurationObjects) override;
 
     /** Handles parameter value changes */
     void parameterValueChanged (Parameter* parameter) override;
 
     /** Resizes buffers when input parameters are changed*/
-    void resizeBuffers();
+    void resizeBuffers() override;
 
     /** Disconnects the socket */
     void disconnectSocket();

--- a/Source/OpenEphysLib.cpp
+++ b/Source/OpenEphysLib.cpp
@@ -38,7 +38,7 @@ extern "C" EXPORT void getLibInfo (Plugin::LibraryInfo* info)
 {
     info->apiVersion = PLUGIN_API_VER;
     info->name = "Ephys Socket";
-    info->libVersion = "1.0.0";
+    info->libVersion = "1.1.0";
     info->numPlugins = NUM_PLUGINS;
 }
 


### PR DESCRIPTION
* Added commands to connect and disconnect the socket. Also a command to query the connection state.
* Unlike other commands, connection state can be modified when the socket is connected, or else it would be impossible to disconnect
* example:

```python
def connect_socket(self) -> bool:
    es_id = self._get_ephys_socket_id()

    response = self._put(
        f"/api/processors/{es_id}/config",
        payload={"text": "ES CONNECT"},
    )

    return response["info"] == "CONNECTED"
```